### PR TITLE
Feat/student lifecycle actions

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -335,6 +335,10 @@ export const api = {
     return gatewayClient.registerSubject(accessToken(session), subjectId)
   },
 
+  async leaveSubject(session, subjectId) {
+    return gatewayClient.leaveSubject(accessToken(session), subjectId)
+  },
+
   async addStudentToSubject(session, subjectId, userId) {
     return gatewayClient.addStudentToSubject(accessToken(session), subjectId, userId)
   },
@@ -360,6 +364,19 @@ export const api = {
     // returns every project the caller can see.
     const response = await gatewayClient.listProjects(accessToken(session), subjectId || '')
     return response.getProjectsList().map(normalizeProject)
+  },
+
+  // One round-trip: returns every (project, teams[]) pair the caller can see. Avoids the
+  // browser doing listProjects + per-project listTeamsByProject. Pass subjectId to scope.
+  async listProjectsWithTeams(session, subjectId) {
+    const response = await gatewayClient.listProjectsWithTeams(
+      accessToken(session),
+      subjectId || '',
+    )
+    return response.getProjectsList().map((entry) => ({
+      project: normalizeProject(entry.getProject()),
+      teams: entry.getTeamsList().map(normalizeTeam),
+    }))
   },
 
   async getProjectNotificationRecipients(session, projectId) {
@@ -388,6 +405,10 @@ export const api = {
     return normalizeTeam(
       await gatewayClient.registerTeam(accessToken(session), projectId, resolvedName),
     )
+  },
+
+  async leaveTeam(session, teamId) {
+    return gatewayClient.leaveTeam(accessToken(session), teamId)
   },
 
   async addTeamMember(session, teamId, studentId) {

--- a/frontend/src/lib/grpcWebGateway.js
+++ b/frontend/src/lib/grpcWebGateway.js
@@ -181,6 +181,11 @@ const methods = {
     gatewayPb.RegisterSubjectGatewayRequest,
     commonPb.Ack,
   ),
+  leaveSubject: unaryDescriptor(
+    '/gateway.FrontendGateway/LeaveSubject',
+    gatewayPb.LeaveSubjectGatewayRequest,
+    commonPb.Ack,
+  ),
   addStudentToSubject: unaryDescriptor(
     '/gateway.FrontendGateway/AddStudentToSubject',
     subjectPb.UserSubjectRequest,
@@ -206,6 +211,11 @@ const methods = {
     projectPb.ListProjectsRequest,
     projectPb.ListProjectsResponse,
   ),
+  listProjectsWithTeams: unaryDescriptor(
+    '/gateway.FrontendGateway/ListProjectsWithTeams',
+    gatewayPb.ListProjectsWithTeamsGatewayRequest,
+    gatewayPb.ListProjectsWithTeamsGatewayResponse,
+  ),
   createProject: unaryDescriptor(
     '/gateway.FrontendGateway/CreateProject',
     gatewayPb.CreateProjectGatewayRequest,
@@ -220,6 +230,11 @@ const methods = {
     '/gateway.FrontendGateway/RegisterTeam',
     projectPb.RegisterTeamRequest,
     projectPb.Team,
+  ),
+  leaveTeam: unaryDescriptor(
+    '/gateway.FrontendGateway/LeaveTeam',
+    projectPb.LeaveTeamRequest,
+    commonPb.Ack,
   ),
   listTeamsByProject: unaryDescriptor(
     '/gateway.FrontendGateway/ListTeamsByProject',
@@ -419,6 +434,12 @@ export const gatewayClient = {
     return client.unary(methods.registerSubject, request, accessToken)
   },
 
+  leaveSubject(accessToken, subjectId) {
+    const request = new gatewayPb.LeaveSubjectGatewayRequest()
+    request.setSubjectId(subjectId || '')
+    return client.unary(methods.leaveSubject, request, accessToken)
+  },
+
   addStudentToSubject(accessToken, subjectId, userId) {
     const request = new subjectPb.UserSubjectRequest()
     request.setSubjectId(subjectId || '')
@@ -445,6 +466,12 @@ export const gatewayClient = {
     request.setSubjectId(subjectId || '')
     request.setTeacherUserId(teacherUserId || '')
     return client.unary(methods.removeTeacherFromSubject, request, accessToken)
+  },
+
+  listProjectsWithTeams(accessToken, subjectId) {
+    const request = new gatewayPb.ListProjectsWithTeamsGatewayRequest()
+    request.setSubjectId(subjectId || '')
+    return client.unary(methods.listProjectsWithTeams, request, accessToken)
   },
 
   listProjects(accessToken, subjectId) {
@@ -480,6 +507,12 @@ export const gatewayClient = {
     request.setProjectId(projectId || '')
     request.setTeamName(teamName || '')
     return client.unary(methods.registerTeam, request, accessToken)
+  },
+
+  leaveTeam(accessToken, teamId) {
+    const request = new projectPb.LeaveTeamRequest()
+    request.setTeamId(teamId || '')
+    return client.unary(methods.leaveTeam, request, accessToken)
   },
 
   listTeamsByProject(accessToken, projectId) {

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -514,15 +514,27 @@ export default function ProjectDetailPage() {
                     justifyContent="space-between"
                     alignItems={{ xs: 'flex-start', md: 'center' }}
                   >
-                    <Box>
-                      <Typography variant="h6">You are not in a team yet</Typography>
-                      <Typography color="text.secondary" sx={{ mt: 0.75 }}>
-                        Create a team for this project, then manage members here.
-                      </Typography>
-                    </Box>
-                    <Button variant="contained" onClick={openCreateTeamDialog}>
-                      Create team
-                    </Button>
+                    {(subject?.user_ids || []).includes(user?.id) ? (
+                      <>
+                        <Box>
+                          <Typography variant="h6">You are not in a team yet</Typography>
+                          <Typography color="text.secondary" sx={{ mt: 0.75 }}>
+                            Create a team for this project, then manage members here.
+                          </Typography>
+                        </Box>
+                        <Button variant="contained" onClick={openCreateTeamDialog}>
+                          Create team
+                        </Button>
+                      </>
+                    ) : (
+                      <Box>
+                        <Typography variant="h6">Subject registration required</Typography>
+                        <Typography color="text.secondary" sx={{ mt: 0.75 }}>
+                          You must register for the &quot;{subject?.name || 'subject'}&quot;
+                          subject before you can create or join a team for this project.
+                        </Typography>
+                      </Box>
+                    )}
                   </Stack>
                 </Paper>
               )}

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -373,6 +373,17 @@ export default function ProjectDetailPage() {
     }
   }
 
+  async function handleLeaveTeam() {
+    if (!ownTeam?.id) return
+    try {
+      await api.leaveTeam(session, ownTeam.id)
+      setSuccess('Left the team.')
+      await loadData()
+    } catch (leaveError) {
+      setError(leaveError.message || 'Failed to leave team')
+    }
+  }
+
   async function handleRemoveMember(studentId) {
     if (!ownTeam?.id) return
     try {
@@ -602,6 +613,18 @@ export default function ProjectDetailPage() {
                           <Typography color="text.secondary" sx={{ fontSize: 14 }}>
                             {(ownTeam.student_ids || []).length} / {project.max_students_per_team} seats used
                           </Typography>
+                        </Stack>
+                      )}
+
+                      {isStudent && !teamDetails[ownTeam.id]?.evaluation && (
+                        <Stack direction="row" spacing={1} sx={{ mt: 0.5 }}>
+                          <Button
+                            color="error"
+                            variant="outlined"
+                            onClick={handleLeaveTeam}
+                          >
+                            Leave team
+                          </Button>
                         </Stack>
                       )}
                     </Stack>

--- a/frontend/src/pages/SubjectsPage.jsx
+++ b/frontend/src/pages/SubjectsPage.jsx
@@ -107,29 +107,46 @@ export default function SubjectsPage() {
     [projects],
   )
 
+  // Subjects in which the current student is on at least one team. Used to hide the
+  // "Leave subject" button — leaving a subject while still belonging to a team there
+  // would leave that team in an inconsistent state.
+  const subjectsWhereStudentHasTeam = useMemo(() => {
+    const studentId = user?.id
+    if (!studentId) return new Set()
+    const result = new Set()
+    for (const project of projects) {
+      const teams = teamsByProject[project.id] || []
+      if (teams.some((team) => (team.student_ids || []).includes(studentId))) {
+        result.add(project.subject_id)
+      }
+    }
+    return result
+  }, [projects, teamsByProject, user?.id])
+
   async function loadData() {
     setLoading(true)
     setError('')
     try {
-      const [subjectData, projectData, userData] = await Promise.all([
+      // Single bundled call replaces listProjects + per-project listTeamsByProject (was N+1).
+      const [subjectData, projectsBundle, userData] = await Promise.all([
         api.listSubjects(session),
-        api.listProjects(session),
+        api.listProjectsWithTeams(session),
         api.listUsers(session),
       ])
 
       const nextSubjects = Array.isArray(subjectData) ? subjectData : subjectData.subjects || []
-      const nextProjects = Array.isArray(projectData) ? projectData : projectData.projects || []
-      const teamLists = await Promise.all(
-        nextProjects.map(async (project) => ({
-          projectId: project.id,
-          teams: await api.listTeamsByProject(session, project.id),
-        })),
+      const bundle = Array.isArray(projectsBundle) ? projectsBundle : []
+      const nextProjects = bundle.map((entry) => entry.project).filter(Boolean)
+      const nextTeamsByProject = Object.fromEntries(
+        bundle
+          .filter((entry) => entry.project?.id)
+          .map((entry) => [entry.project.id, entry.teams || []]),
       )
 
       setSubjects(nextSubjects)
       setProjects(nextProjects)
       setKnownUsers(Array.isArray(userData) ? userData : [])
-      setTeamsByProject(Object.fromEntries(teamLists.map((item) => [item.projectId, item.teams])))
+      setTeamsByProject(nextTeamsByProject)
     } catch (loadError) {
       setError(loadError.message || 'Failed to load subject workspace')
     } finally {
@@ -148,6 +165,16 @@ export default function SubjectsPage() {
       await loadData()
     } catch (registerError) {
       setError(registerError.message || 'Failed to register to subject')
+    }
+  }
+
+  async function handleLeaveSubject(subjectId) {
+    try {
+      await api.leaveSubject(session, subjectId)
+      setSuccess('Unenrolled from subject.')
+      await loadData()
+    } catch (leaveError) {
+      setError(leaveError.message || 'Failed to leave subject')
     }
   }
 
@@ -454,6 +481,17 @@ export default function SubjectsPage() {
                               Register to subject
                             </Button>
                           )}
+                        {user?.role === 'student' &&
+                          (subject.user_ids || []).includes(user?.id) &&
+                          !subjectsWhereStudentHasTeam.has(subject.id) && (
+                            <Button
+                              color="error"
+                              variant="outlined"
+                              onClick={() => handleLeaveSubject(subject.id)}
+                            >
+                              Leave subject
+                            </Button>
+                          )}
                         {['teacher', 'admin'].includes(user?.role) && (
                           <Button
                             variant="contained"
@@ -623,14 +661,16 @@ export default function SubjectsPage() {
                                     >
                                       View teams
                                     </Button>
-                                    {user?.role === 'student' && !ownTeam && (
-                                      <Button
-                                        variant="contained"
-                                        onClick={() => openCreateTeamDialog(project.id)}
-                                      >
-                                        Create team
-                                      </Button>
-                                    )}
+                                    {user?.role === 'student' &&
+                                      !ownTeam &&
+                                      (subject.user_ids || []).includes(user?.id) && (
+                                        <Button
+                                          variant="contained"
+                                          onClick={() => openCreateTeamDialog(project.id)}
+                                        >
+                                          Create team
+                                        </Button>
+                                      )}
                                     {user?.role === 'student' && ownTeam && (
                                       <Button
                                         variant="contained"

--- a/frontend/src/pages/SubjectsPage.jsx
+++ b/frontend/src/pages/SubjectsPage.jsx
@@ -108,7 +108,7 @@ export default function SubjectsPage() {
   )
 
   // Subjects in which the current student is on at least one team. Used to hide the
-  // "Leave subject" button — leaving a subject while still belonging to a team there
+  // "Unregister from subject" button — unregistering while still on a team there
   // would leave that team in an inconsistent state.
   const subjectsWhereStudentHasTeam = useMemo(() => {
     const studentId = user?.id
@@ -171,10 +171,10 @@ export default function SubjectsPage() {
   async function handleLeaveSubject(subjectId) {
     try {
       await api.leaveSubject(session, subjectId)
-      setSuccess('Unenrolled from subject.')
+      setSuccess('Unregistered from subject.')
       await loadData()
     } catch (leaveError) {
-      setError(leaveError.message || 'Failed to leave subject')
+      setError(leaveError.message || 'Failed to unregister from subject')
     }
   }
 
@@ -489,7 +489,7 @@ export default function SubjectsPage() {
                               variant="outlined"
                               onClick={() => handleLeaveSubject(subject.id)}
                             >
-                              Leave subject
+                              Unregister from subject
                             </Button>
                           )}
                         {['teacher', 'admin'].includes(user?.role) && (

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -28,12 +28,18 @@ service FrontendGateway {
   rpc UpdateSubject(subject.UpdateSubjectRequest) returns (subject.Subject);
   rpc DeleteSubject(subject.DeleteSubjectRequest) returns (common.Ack);
   rpc RegisterSubject(RegisterSubjectGatewayRequest) returns (common.Ack);
+  rpc LeaveSubject(LeaveSubjectGatewayRequest) returns (common.Ack);
   rpc AddStudentToSubject(subject.UserSubjectRequest) returns (common.Ack);
   rpc RemoveStudentFromSubject(subject.UserSubjectRequest) returns (common.Ack);
   rpc AssignTeacherToSubject(subject.TeacherSubjectRequest) returns (subject.Subject);
   rpc RemoveTeacherFromSubject(subject.TeacherSubjectRequest) returns (subject.Subject);
 
   rpc ListProjects(project.ListProjectsRequest) returns (project.ListProjectsResponse);
+  // Single-call replacement for "list projects + per-project list_teams_by_project". When
+  // subject_id is empty the router fans out across every subject server-side. Each entry
+  // bundles a Project with its Teams (basic shape, student_ids enriched).
+  rpc ListProjectsWithTeams(ListProjectsWithTeamsGatewayRequest)
+      returns (ListProjectsWithTeamsGatewayResponse);
   rpc GetProject(project.GetProjectRequest) returns (project.Project);
   rpc CreateProject(CreateProjectGatewayRequest) returns (project.Project);
   rpc UpdateProject(project.UpdateProjectRequest) returns (project.Project);
@@ -80,6 +86,8 @@ service FrontendGateway {
 
 message RegisterSubjectGatewayRequest { string subject_id = 1; }
 
+message LeaveSubjectGatewayRequest { string subject_id = 1; }
+
 message ChangePasswordGatewayRequest {
   string current_password = 1;
   string new_password = 2;
@@ -122,6 +130,17 @@ message ListProjectTeamDetailsGatewayRequest { string project_id = 1; }
 
 message ListProjectTeamDetailsGatewayResponse {
   repeated project.TeamDetail teams = 1;
+}
+
+message ListProjectsWithTeamsGatewayRequest { string subject_id = 1; }
+
+message ProjectWithTeams {
+  project.Project project = 1;
+  repeated project.Team teams = 2;
+}
+
+message ListProjectsWithTeamsGatewayResponse {
+  repeated ProjectWithTeams projects = 1;
 }
 
 message CancelScheduledNotificationGatewayRequest { string batch_id = 1; }

--- a/services/router-rust/src/gateway.rs
+++ b/services/router-rust/src/gateway.rs
@@ -19,9 +19,10 @@ use crate::proto::{
         frontend_gateway_server::FrontendGateway, CancelScheduledNotificationGatewayRequest,
         ChangePasswordGatewayRequest, CreateNotificationGatewayRequest,
         CreateNotificationGatewayResponse, CreateProjectGatewayRequest,
-        ListNotificationsGatewayResponse, ListProjectTeamDetailsGatewayRequest,
-        ListProjectTeamDetailsGatewayResponse, ListTeamsByProjectGatewayResponse,
-        NotificationWithSender, RegisterSubjectGatewayRequest,
+        LeaveSubjectGatewayRequest, ListNotificationsGatewayResponse,
+        ListProjectTeamDetailsGatewayRequest, ListProjectTeamDetailsGatewayResponse,
+        ListProjectsWithTeamsGatewayRequest, ListProjectsWithTeamsGatewayResponse,
+        ListTeamsByProjectGatewayResponse, NotificationWithSender, RegisterSubjectGatewayRequest,
         RescheduleScheduledNotificationGatewayRequest,
     },
     notification::{ListScheduledNotificationsResponse, MarkAsReadRequest, Notification},
@@ -282,6 +283,13 @@ impl FrontendGateway for FrontendGatewayService {
         subjects::register_subject(self, request).await
     }
 
+    async fn leave_subject(
+        &self,
+        request: Request<LeaveSubjectGatewayRequest>,
+    ) -> Result<Response<Ack>, Status> {
+        subjects::leave_subject(self, request).await
+    }
+
     async fn add_student_to_subject(
         &self,
         request: Request<UserSubjectRequest>,
@@ -315,6 +323,13 @@ impl FrontendGateway for FrontendGatewayService {
         request: Request<ListProjectsRequest>,
     ) -> Result<Response<ListProjectsResponse>, Status> {
         projects::list_projects(self, request).await
+    }
+
+    async fn list_projects_with_teams(
+        &self,
+        request: Request<ListProjectsWithTeamsGatewayRequest>,
+    ) -> Result<Response<ListProjectsWithTeamsGatewayResponse>, Status> {
+        projects::list_projects_with_teams(self, request).await
     }
 
     async fn create_project(

--- a/services/router-rust/src/gateway/projects.rs
+++ b/services/router-rust/src/gateway/projects.rs
@@ -193,6 +193,35 @@ pub(super) async fn register_team(
     FrontendGatewayService::require_non_empty(&body.project_id, "project id")?;
     FrontendGatewayService::require_non_empty(&body.team_name, "team name")?;
 
+    // Enforce: a student can only create a team in a project whose subject they're
+    // enrolled in. The frontend hides the button for non-enrolled students; this is the
+    // belt-and-suspenders check so a determined caller can't bypass via grpcurl.
+    if current_user.role == UserRole::Student {
+        let project = service
+            .state
+            .project_client()
+            .get_project(ctx.clone().into_request(GetProjectRequest {
+                project_id: body.project_id.clone(),
+            })?)
+            .await?
+            .into_inner();
+        let subject = service
+            .state
+            .subject_client()
+            .get_subject(ctx.clone().into_request(
+                crate::proto::subject::GetSubjectRequest {
+                    subject_id: project.subject_id.clone(),
+                },
+            )?)
+            .await?
+            .into_inner();
+        if !subject.user_ids.iter().any(|id| id == &current_user.user_id) {
+            return Err(Status::permission_denied(
+                "register for the subject before creating a team in its project",
+            ));
+        }
+    }
+
     let response = service
         .state
         .project_client()

--- a/services/router-rust/src/gateway/projects.rs
+++ b/services/router-rust/src/gateway/projects.rs
@@ -12,7 +12,8 @@ use crate::proto::eval::{ListProjectEvaluationsRequest, ProjectEvaluation};
 
 use crate::proto::gateway::{
     CreateProjectGatewayRequest, ListProjectTeamDetailsGatewayRequest,
-    ListProjectTeamDetailsGatewayResponse, ListTeamsByProjectGatewayResponse,
+    ListProjectTeamDetailsGatewayResponse, ListProjectsWithTeamsGatewayRequest,
+    ListProjectsWithTeamsGatewayResponse, ListTeamsByProjectGatewayResponse, ProjectWithTeams,
 };
 
 use crate::proto::project::{
@@ -295,17 +296,19 @@ pub(super) async fn list_project_team_details(
         {
             Ok(response) => {
                 let mut detail = response.into_inner();
-                if is_student {
-                    let belongs = detail.leader_student_id == current_user.user_id
+                let belongs = is_student
+                    && (detail.leader_student_id == current_user.user_id
                         || detail
                             .students
                             .iter()
-                            .any(|user| user.id == current_user.user_id);
-                    if !belongs {
-                        continue;
-                    }
-                }
-                if let Some(evaluation) = evaluations_by_team.get(&detail.team_id) {
+                            .any(|user| user.id == current_user.user_id));
+                if is_student && !belongs {
+                    // Students still need to see other teams (to know who's on them and to
+                    // request joining), but they must not see those teams' submission file or
+                    // grade. Strip the private fields and keep the rest.
+                    detail.submission = None;
+                    detail.evaluation = None;
+                } else if let Some(evaluation) = evaluations_by_team.get(&detail.team_id) {
                     detail.evaluation = Some(evaluation.clone());
                 }
                 teams.push(detail);
@@ -322,6 +325,136 @@ pub(super) async fn list_project_team_details(
     }
 
     Ok(Response::new(ListProjectTeamDetailsGatewayResponse { teams }))
+}
+
+pub(super) async fn list_projects_with_teams(
+    service: &FrontendGatewayService,
+    request: Request<ListProjectsWithTeamsGatewayRequest>,
+) -> Result<Response<ListProjectsWithTeamsGatewayResponse>, Status> {
+    let ctx = ForwardContext::from_request(&request);
+    let body = request.into_inner();
+    let subject_filter = body.subject_id.trim().to_string();
+
+    // Collect target projects. With a subject filter we hit project-service once;
+    // without, we fan out across every subject server-side.
+    let mut all_projects: Vec<Project> = Vec::new();
+    if !subject_filter.is_empty() {
+        let response = service
+            .state
+            .project_client()
+            .list_projects(ctx.clone().into_request(ListProjectsRequest {
+                subject_id: subject_filter,
+            })?)
+            .await?
+            .into_inner();
+        all_projects.extend(response.projects);
+    } else {
+        let subjects = service
+            .state
+            .subject_client()
+            .list_subjects(
+                ctx.clone()
+                    .into_request(crate::proto::subject::ListSubjectsRequest {})?,
+            )
+            .await?
+            .into_inner()
+            .subjects;
+        for subject in subjects {
+            match service
+                .state
+                .project_client()
+                .list_projects(ctx.clone().into_request(ListProjectsRequest {
+                    subject_id: subject.id.clone(),
+                })?)
+                .await
+            {
+                Ok(response) => all_projects.extend(response.into_inner().projects),
+                Err(status) => {
+                    tracing::warn!(
+                        subject_id = %subject.id,
+                        code = ?status.code(),
+                        message = status.message(),
+                        "list_projects_with_teams: per-subject project fetch failed; skipping"
+                    );
+                }
+            }
+        }
+    }
+
+    // For each project enrich teams with student_ids (matches list_teams_by_project's shape).
+    let mut entries = Vec::with_capacity(all_projects.len());
+    for project in all_projects {
+        let project_id = project.project_id.clone();
+        let teams = match service
+            .state
+            .project_client()
+            .list_teams_by_project(ctx.clone().into_request(ListTeamsByProjectRequest {
+                project_id: project_id.clone(),
+            })?)
+            .await
+        {
+            Ok(response) => {
+                let listing = response.into_inner();
+                let mut teams = Vec::with_capacity(listing.teams.len());
+                for team in listing.teams {
+                    match service
+                        .state
+                        .project_client()
+                        .get_team(ctx.clone().into_request(GetTeamRequest {
+                            team_id: team.team_id.clone(),
+                        })?)
+                        .await
+                    {
+                        Ok(detail_response) => {
+                            teams.push(team_from_detail(detail_response.into_inner()));
+                        }
+                        Err(status) => {
+                            tracing::warn!(
+                                team_id = %team.team_id,
+                                code = ?status.code(),
+                                message = status.message(),
+                                "list_projects_with_teams: get_team enrichment failed; \
+                                 falling back to leader-only student_ids"
+                            );
+                            let leader = team.leader_student_id.clone();
+                            let student_ids = if leader.is_empty() {
+                                Vec::new()
+                            } else {
+                                vec![leader.clone()]
+                            };
+                            teams.push(Team {
+                                team_id: team.team_id,
+                                project_id: team.project_id,
+                                name: team.name,
+                                leader_student_id: leader,
+                                student_ids,
+                            });
+                        }
+                    }
+                }
+                teams
+            }
+            Err(status) => {
+                tracing::warn!(
+                    project_id = %project_id,
+                    code = ?status.code(),
+                    message = status.message(),
+                    "list_projects_with_teams: list_teams_by_project failed; \
+                     returning project with no teams"
+                );
+                Vec::new()
+            }
+        };
+
+        entries.push(ProjectWithTeams {
+            project: Some(project),
+            teams,
+        });
+    }
+
+    Ok(Response::new(ListProjectsWithTeamsGatewayResponse {
+        projects: entries,
+    }))
 }
 
 pub(super) async fn list_teams_by_project(

--- a/services/router-rust/src/gateway/subjects.rs
+++ b/services/router-rust/src/gateway/subjects.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::proto::gateway::LeaveSubjectGatewayRequest;
 use crate::proto::subject::{
     GetSubjectRequest, ListSubjectsRequest, TeacherSubjectRequest, UserSubjectRequest,
 };
@@ -186,6 +187,28 @@ pub(super) async fn register_subject(
         .state
         .subject_client()
         .register_user_to_subject(ctx.into_request(UserSubjectRequest {
+            subject_id: body.subject_id,
+            user_id: current_user.user_id,
+        })?)
+        .await?
+        .into_inner();
+
+    Ok(Response::new(response))
+}
+
+pub(super) async fn leave_subject(
+    service: &FrontendGatewayService,
+    request: Request<LeaveSubjectGatewayRequest>,
+) -> Result<Response<Ack>, Status> {
+    let current_user = FrontendGatewayService::current_user(&request)?;
+    let ctx = ForwardContext::from_request(&request);
+    let body = request.into_inner();
+    FrontendGatewayService::require_non_empty(&body.subject_id, "subject id")?;
+
+    let response = service
+        .state
+        .subject_client()
+        .remove_user_from_subject(ctx.into_request(UserSubjectRequest {
             subject_id: body.subject_id,
             user_id: current_user.user_id,
         })?)

--- a/services/router-rust/src/grpc_auth.rs
+++ b/services/router-rust/src/grpc_auth.rs
@@ -128,6 +128,7 @@ fn route_auth_policy(path: &str) -> RouteAuthPolicy {
         }
         "/gateway.FrontendGateway/SubmitProject" => RouteAuthPolicy::Roles(STUDENT_OR_ADMIN),
         "/gateway.FrontendGateway/RegisterSubject" => RouteAuthPolicy::Roles(STUDENT_ONLY),
+        "/gateway.FrontendGateway/LeaveSubject" => RouteAuthPolicy::Roles(STUDENT_ONLY),
         _ => RouteAuthPolicy::Authenticated,
     }
 }


### PR DESCRIPTION
Introduce some constraints to the registration process.

- Students must be registered for a subject in order to create or join a team for a project of that subject.
- Students cannot be unregistered from a subject if they are in a project team for that subject.
- Once a student has received an evaluation, they cannot leave the team that was evaluated.

This also implies that if a student is evaluated in a project, they effectively cannot unregister from the subject, which helps with consistency.

These guards are done in the `router`. I'm not sure if this is the best place to do it (or should the router only be responsible for routing, leaving these things to the concrete services?). But that's for another time, this is a kind of hot fix for the issue.

I'm also not sure if the admin should be able to use the `leave subject` endpoint. Maybe not. but not sure. I'm currently limiting it to students only.